### PR TITLE
Fixes #15

### DIFF
--- a/reactive/flannel.py
+++ b/reactive/flannel.py
@@ -227,4 +227,5 @@ def cleanup_deployment():
     files = ['/usr/local/bin/flanneld',
              '/lib/systemd/system/flannel']
     for f in files:
-        os.remove(f)
+        if os.path.exists(f):
+            os.remove(f)

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -1,3 +1,3 @@
-tests: [*]
+tests: "[*]"
 packages:
   - amulet


### PR DESCRIPTION
The stop hook was erroring attempting to remove paths that didn't exist
or were previously removed. This resolves that with an exists check.
This also fixes a typo in tests/tests.yaml

Fixes #15 
