### PR TITLE
Self cleanup on stop hook

### DIFF
--- a/reactive/flannel.py
+++ b/reactive/flannel.py
@@ -222,8 +222,6 @@ def reset_states_and_redeploy():
 @hook('stop')
 def cleanup_deployment():
     ''' Terminate services, and remove the deployed bins '''
-
-
     host.service_stop('flannel')
 
     # Stop and remove the flannel bridge
@@ -238,7 +236,8 @@ def cleanup_deployment():
         # just allow it to fail and leave the interface up. More data will
         # need to be collected to resolve this particular code path, as it
         # worked when testing.
-        pass
+        hookenv.log('Unable to remove iface flannel.1')
+        hookenv.log('Potential indication that cleanup is not possible')
 
     # List of files we expect to need to clean up
     files = ['/usr/local/bin/flanneld',


### PR DESCRIPTION
This code path bloats the teardown time by about 20 seconds, but
successfully cleans up the interface and the associated files upon
executing the stop hook
