### PR TITLE
migrate to the nagios layer

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -11,19 +11,3 @@ options:
     default: 10.1.0.0/16
     description: |
       Network CIDR to assign to Flannel
-  nagios_context:
-    default: "juju"
-    type: string
-    description: |
-      Used by the nrpe subordinate charm.
-      A string that will be prepended to instance name to set the host name
-      in nagios. So for instance the hostname would be something like:
-          juju-myservice-0
-      If you're running multiple environments with the same services in them
-      this allows you to differentiate between them.
-  nagios_servicegroups:
-    default: ""
-    type: string
-    description: |
-      A comma-separated list of nagios servicegroups.
-      If left empty, the nagios_context will be used as the servicegroup.

--- a/layer.yaml
+++ b/layer.yaml
@@ -3,4 +3,5 @@ includes:
    - 'interface:kubernetes-cni'
    - 'interface:nrpe-external-master'
    - 'layer:basic'
+   - 'layer:nagios'
 repo: https://github.com/juju-solutions/charm-flannel.git


### PR DESCRIPTION
Instead of specifying the nrpe-related config options in all the charms,
it's better to use the nagios layer.