### PR TITLE
Fix for etcd-retry scenario

### DIFF
--- a/lib/charms/flannel/common.py
+++ b/lib/charms/flannel/common.py
@@ -1,0 +1,30 @@
+from time import sleep
+
+
+def retry(times, delay_secs):
+    """ Decorator for retrying a method call.
+    Args:
+        times: How many times should we retry before giving up
+        delay_secs: Delay in secs
+    Returns: A callable that would return the last call outcome
+    """
+
+    def retry_decorator(func):
+        """ Decorator to wrap the function provided.
+        Args:
+            func: Provided function should return either True od False
+        Returns: A callable that would return the last call outcome
+        """
+        def _wrapped(*args, **kwargs):
+            res = func(*args, **kwargs)
+            attempt = 0
+            while not res and attempt < times:
+                sleep(delay_secs)
+                res = func(*args, **kwargs)
+                if res:
+                    break
+                attempt += 1
+            return res
+        return _wrapped
+
+    return retry_decorator

--- a/reactive/flannel.py
+++ b/reactive/flannel.py
@@ -81,7 +81,7 @@ def install_etcd_credentials(etcd):
 
 
 @when('flannel.binaries.installed', 'flannel.etcd.credentials.installed',
-      'etcd.available')
+      'etcd.tls.available')
 @when_not('flannel.service.installed')
 def install_flannel_service(etcd):
     ''' Install the flannel service. '''

--- a/reactive/flannel.py
+++ b/reactive/flannel.py
@@ -3,6 +3,8 @@ import json
 from shlex import split
 from subprocess import check_output, check_call, CalledProcessError, STDOUT
 
+from charms.flannel.common import retry
+
 from charms.reactive import set_state, remove_state, when, when_not, hook
 from charms.reactive import when_any
 from charms.templating.jinja2 import render
@@ -109,8 +111,23 @@ def reconfigure_flannel_service():
 @when('flannel.binaries.installed', 'flannel.etcd.credentials.installed',
       'etcd.available')
 @when_not('flannel.network.configured')
+def invoke_configure_network(etcd):
+    ''' invoke network configuration and adjust states '''
+    status_set('maintenance', 'Negotiating flannel network subnet')
+    if configure_network(etcd):
+        set_state('flannel.network.configured')
+        remove_state('flannel.service.started')
+    else:
+        status_set('waiting', 'Waiting on etcd Coordination.')
+
+
+@retry(times=3, delay_secs=20)
 def configure_network(etcd):
-    ''' Store initial flannel data in etcd. '''
+    ''' Store initial flannel data in etcd.
+
+    Returns True if the operation completed successfully.
+
+    '''
     data = json.dumps({
         'Network': config('cidr'),
         'Backend': {
@@ -123,9 +140,14 @@ def configure_network(etcd):
     cmd += "--key-file {0} ".format(ETCD_KEY_PATH)
     cmd += "--ca-file {0} ".format(ETCD_CA_PATH)
     cmd += "set /coreos.com/network/config '{0}'".format(data)
-    check_call(split(cmd))
-    set_state('flannel.network.configured')
-    remove_state('flannel.service.started')
+    try:
+        check_call(split(cmd))
+        return True
+
+    except CalledProcessError:
+        log('Unexpected error configuring network. Assuming etcd not'
+            ' ready. Will retry in 20s')
+        return False
 
 
 @when('config.changed.cidr')

--- a/reactive/flannel.py
+++ b/reactive/flannel.py
@@ -118,7 +118,7 @@ def invoke_configure_network(etcd):
         set_state('flannel.network.configured')
         remove_state('flannel.service.started')
     else:
-        status_set('waiting', 'Waiting on etcd coordination.')
+        status_set('waiting', 'Waiting on etcd.')
 
 
 @retry(times=3, delay_secs=20)

--- a/reactive/flannel.py
+++ b/reactive/flannel.py
@@ -113,12 +113,12 @@ def reconfigure_flannel_service():
 @when_not('flannel.network.configured')
 def invoke_configure_network(etcd):
     ''' invoke network configuration and adjust states '''
-    status_set('maintenance', 'Negotiating flannel network subnet')
+    status_set('maintenance', 'Negotiating flannel network subnet.')
     if configure_network(etcd):
         set_state('flannel.network.configured')
         remove_state('flannel.service.started')
     else:
-        status_set('waiting', 'Waiting on etcd Coordination.')
+        status_set('waiting', 'Waiting on etcd coordination.')
 
 
 @retry(times=3, delay_secs=20)


### PR DESCRIPTION
This catches the error emitted when the etcd unit is still configuring
and not available. The self registration code would return > 0 and cause
the charm to halt execution causing juju-wait and conjure-up to fail
deployments.

This shamelessly takes the retry decorator that was piloted in the
kubernetes charms and embeds it in lib/charms/flannel/common.py

Closes https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/312