### PR TITLE
Fix lint error / remove stray import

### DIFF
--- a/reactive/flannel.py
+++ b/reactive/flannel.py
@@ -1,6 +1,5 @@
 import os
 import json
-import subprocess
 from shlex import split
 from subprocess import check_output, check_call, CalledProcessError, STDOUT
 


### PR DESCRIPTION
Oops. We picked up a stray import in https://github.com/juju-solutions/charm-flannel/pull/35 and now our CI is fussing:

```
DEBUG:runner:reactive/flannel.py:3:1: F401 'subprocess' imported but unused
DEBUG:runner:Makefile:17: recipe for target 'lint' failed
```

This should fix it.