### PR TITLE
Add hairpin configuration

### DIFF
--- a/templates/10-flannel.conflist
+++ b/templates/10-flannel.conflist
@@ -4,6 +4,7 @@
       {
         "type": "flannel",
         "delegate": {
+          "hairpinMode": true,
           "isDefaultGateway": true
         }
       },


### PR DESCRIPTION
Containers within a pod need this to be able to access the other co-located containers using the cluster ip. 