### PR TITLE
Make built resource filenames consistent

### DIFF
--- a/build-flannel-resources.sh
+++ b/build-flannel-resources.sh
@@ -47,7 +47,7 @@ mkdir "$temp_dir"
       echo "build script commit: $build_script_commit" >> BUILD_INFO
       cp "$temp_dir"/etcd/bin/etcdctl .
       cp "$temp_dir"/flannel/dist/flanneld-$arch ./flanneld
-      tar -caf "$temp_dir/flannel-$arch-$FLANNEL_VERSION.tar.gz" .
+      tar -caf "$temp_dir/flannel-$arch.tar.gz" .
     )
   done
 )


### PR DESCRIPTION
Dropping the flannel version from the resource filename so that we can refer to the resources more consistently in [resource-spec.yaml](https://github.com/juju-solutions/kubernetes-jenkins/blob/89f4551b968ea26735d57b9c737a5c78513b8450/jobs/build-charms/resource-spec.yaml).

I do like having the version in the filename, but dropping it here seems worthwhile for the quick fix.