### PR TITLE
Add cniVersion to cni conf, for Multus support

### DIFF
--- a/templates/10-flannel.conflist
+++ b/templates/10-flannel.conflist
@@ -1,5 +1,6 @@
 {
     "name": "CDK-flannel-network",
+    "cniVersion": "0.3.1",
     "plugins": [
       {
         "type": "flannel",


### PR DESCRIPTION
When the `cniVersion` field is omitted, we hit this bug in Multus: https://github.com/intel/multus-cni/issues/289 (which isn't really about SR-IOV as far as I can tell).

Multus needs more design work before we merge in the main stuff, but I figure there's no harm in merging this one in advance.