### PR TITLE
Update to Flannel 0.11.0

### DIFF
--- a/build-flannel-resources.sh
+++ b/build-flannel-resources.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eux
 
-FLANNEL_VERSION=${FLANNEL_VERSION:-"v0.10.0"}
+FLANNEL_VERSION=${FLANNEL_VERSION:-"v0.11.0"}
 ETCD_VERSION=${ETCD_VERSION:-"v2.3.7"}
 
 ARCH=${ARCH:-"amd64 arm64 s390x"}


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/charm-flannel/+bug/1841838

* Updated Flannel to 0.11.0, which is the latest version ([source](https://github.com/coreos/flannel/releases))

I tested using a local [bundle.yaml](https://gist.github.com/Cynerva/4ab2bd141b694dc5b9d6dcbdf67112d1) that includes components from this PR along with [charm-kubernetes-worker#33](https://github.com/charmed-kubernetes/charm-kubernetes-worker/pull/33) and [cdk-addons#143](https://github.com/charmed-kubernetes/cdk-addons/pull/143). I deployed the bundle and ran validation with "slow" tests skipped:
```
$ pytest -s --no-print-logs -m "not slow" validation.py --controller aws-dev --model test2
...
Results (937.29s):
      16 passed
       4 skipped
       1 deselected
```