### PR TITLE
Fix conformance test failure due to IP masquerading

### DIFF
--- a/templates/flannel.service
+++ b/templates/flannel.service
@@ -5,7 +5,7 @@ Wants=network-online.target
 After=network.target network-online.target
 
 [Service]
-ExecStart=/usr/local/bin/flanneld -iface={{ iface }} -etcd-endpoints={{ connection_string }} -etcd-certfile={{ cert_path }}/client-cert.pem -etcd-keyfile={{ cert_path }}/client-key.pem  -etcd-cafile={{ cert_path }}/client-ca.pem
+ExecStart=/usr/local/bin/flanneld -iface={{ iface }} -etcd-endpoints={{ connection_string }} -etcd-certfile={{ cert_path }}/client-cert.pem -etcd-keyfile={{ cert_path }}/client-key.pem  -etcd-cafile={{ cert_path }}/client-ca.pem --ip-masq
 TimeoutStartSec=0
 Restart=on-failure
 LimitNOFILE=655536


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/charm-canal/+bug/1859520 for flannel

This adds the `--ip-masq` option to flanneld, which results in the following:
* flanneld will handle ip masquerading for the 10.1.0.0/16 block
* the flannel cni plugin will *stop* handling masquerading for 10.1.x.0/24 blocks

The end result is that communication between pods that reside in different 10.1.x.0/24 subnets will no longer be masqueraded. Any traffic leaving the 10.1.0.0/16 block, however, will still be masqueraded properly.

This is necessary for the the k8s 1.17 conformance tests, since the guestbook application test assumes that pod-to-pod traffic is not masqueraded. It is worth noting that https://github.com/kubernetes/kubernetes/pull/85599 will remove that assumption and is scheduled for k8s 1.18.