### PR TITLE
Send cni-conf-file to cni relation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+python:
+  - "3.5"
+install:
+  - pip install tox-travis
+script:
+  - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
   - "3.5"
+  - "3.6"
+  - "3.7"
 install:
   - pip install tox-travis
 script:

--- a/reactive/flannel.py
+++ b/reactive/flannel.py
@@ -219,7 +219,7 @@ def start_flannel_service():
 @when_not('flannel.cni.available')
 def set_available(cni):
     ''' Indicate to the CNI provider that we're ready. '''
-    cni.set_config(cidr=config('cidr'))
+    cni.set_config(cidr=config('cidr'), cni_conf_file='10-flannel.conflist')
     set_state('flannel.cni.available')
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,28 @@
+import sys
+from unittest.mock import MagicMock
+
+
+def identity(x):
+    return x
+
+
+charmhelpers = MagicMock()
+sys.modules['charmhelpers'] = charmhelpers
+sys.modules['charmhelpers.core'] = charmhelpers.core
+sys.modules['charmhelpers.core.hookenv'] = charmhelpers.core.hookenv
+sys.modules['charmhelpers.core.host'] = charmhelpers.core.host
+sys.modules['charmhelpers.contrib'] = charmhelpers.contrib
+sys.modules['charmhelpers.contrib.charmsupport'] = \
+    charmhelpers.contrib.charmsupport
+
+reactive = MagicMock()
+sys.modules['charms.reactive'] = reactive
+sys.modules['charms.reactive.helpers'] = reactive.helpers
+reactive.when.return_value = identity
+reactive.when_any.return_value = identity
+reactive.when_not.return_value = identity
+reactive.hook.return_value = identity
+
+templating = MagicMock()
+sys.modules['charms.templating'] = templating
+sys.modules['charms.templating.jinja2'] = templating.jinja2

--- a/tests/test_flannel.py
+++ b/tests/test_flannel.py
@@ -1,0 +1,15 @@
+from unittest.mock import MagicMock
+from reactive import flannel
+from charmhelpers.core import hookenv
+from charms.reactive import set_state
+
+
+def test_set_available():
+    cni = MagicMock()
+    hookenv.config.return_value = '192.168.0.0/16'
+    flannel.set_available(cni)
+    cni.set_config.assert_called_once_with(
+        cidr='192.168.0.0/16',
+        cni_conf_file='10-flannel.conflist'
+    )
+    set_state.assert_called_once_with('flannel.cni.available')

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -1,2 +1,0 @@
-packages:
-  - amulet

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,21 @@
+[tox]
+skipsdist = True
+envlist = lint,py3
+
+[tox:travis]
+3.5: lint,py3
+
+[testenv]
+basepython = python3
+setenv =
+    PYTHONPATH={toxinidir}:{toxinidir}/lib
+deps =
+    pyyaml
+    pytest
+    flake8
+    ipdb
+commands = pytest --tb native -s {posargs}
+
+[testenv:lint]
+envdir = {toxworkdir}/py3
+commands = flake8 {toxinidir}

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,8 @@ envlist = lint,py3
 
 [tox:travis]
 3.5: lint,py3
+3.6: lint,py3
+3.7: lint,py3
 
 [testenv]
 basepython = python3


### PR DESCRIPTION
Partial fix for https://bugs.launchpad.net/charm-kubernetes-master/+bug/1861709

Please be careful merging this, as it's mutually dependent on the work of other PRs in that issue. They will need to be merged together.

This updates flannel to send cni-conf-file to the cni relation.