### PR TITLE
Add support for series upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.tox/
+__pycache__/
+*.pyc

--- a/layer.yaml
+++ b/layer.yaml
@@ -5,6 +5,7 @@ includes:
    - 'layer:basic'
    - 'layer:debug'
    - 'layer:nagios'
+   - 'layer:status'
 repo: https://github.com/juju-solutions/charm-flannel.git
 options:
   basic:

--- a/reactive/flannel.py
+++ b/reactive/flannel.py
@@ -291,6 +291,11 @@ def reset_states_and_redeploy():
         log(str(e))
 
 
+@hook('pre-series-upgrade')
+def pre_series_upgrade():
+    status_set('blocked', 'Series upgrade in progress')
+
+
 @hook('stop')
 def cleanup_deployment():
     ''' Terminate services, and remove the deployed bins '''

--- a/reactive/flannel.py
+++ b/reactive/flannel.py
@@ -10,11 +10,13 @@ from charms.reactive import when_any
 from charms.templating.jinja2 import render
 from charmhelpers.core.host import service_start, service_stop, service_restart
 from charmhelpers.core.host import service_running, service
-from charmhelpers.core.hookenv import log, status_set, resource_get
+from charmhelpers.core.hookenv import log, resource_get
 from charmhelpers.core.hookenv import config, application_version_set
 from charmhelpers.core.hookenv import network_get
 from charmhelpers.contrib.charmsupport import nrpe
 from charms.reactive.helpers import data_changed
+
+from charms.layer import status
 
 
 ETCD_PATH = '/etc/ssl/flannel'
@@ -32,20 +34,20 @@ def install_flannel_binaries():
     except Exception:
         message = 'Error fetching the flannel resource.'
         log(message)
-        status_set('blocked', message)
+        status.blocked(message)
         return
     if not archive:
         message = 'Missing flannel resource.'
         log(message)
-        status_set('blocked', message)
+        status.blocked(message)
         return
     filesize = os.stat(archive).st_size
     if filesize < 1000000:
         message = 'Incomplete flannel resource'
         log(message)
-        status_set('blocked', message)
+        status.blocked(message)
         return
-    status_set('maintenance', 'Unpacking flannel resource.')
+    status.maintenance('Unpacking flannel resource.')
     charm_dir = os.getenv('CHARM_DIR')
     unpack_path = os.path.join(charm_dir, 'files', 'flannel')
     os.makedirs(unpack_path, exist_ok=True)
@@ -121,7 +123,7 @@ def get_bind_address_interface():
 @when_not('flannel.service.installed')
 def install_flannel_service(etcd):
     ''' Install the flannel service. '''
-    status_set('maintenance', 'Installing flannel service.')
+    status.maintenance('Installing flannel service.')
     # keep track of our etcd conn string and cert info so we can detect when it
     # changes later
     data_changed('flannel_etcd_connections', etcd.get_connection_string())
@@ -158,12 +160,12 @@ def etcd_changed(etcd):
 @when_not('flannel.network.configured')
 def invoke_configure_network(etcd):
     ''' invoke network configuration and adjust states '''
-    status_set('maintenance', 'Negotiating flannel network subnet.')
+    status.maintenance('Negotiating flannel network subnet.')
     if configure_network(etcd):
         set_state('flannel.network.configured')
         remove_state('flannel.service.started')
     else:
-        status_set('waiting', 'Waiting on etcd.')
+        status.waiting('Waiting on etcd.')
 
 
 @retry(times=3, delay_secs=20)
@@ -206,7 +208,7 @@ def reconfigure_network():
 @when_not('flannel.service.started')
 def start_flannel_service():
     ''' Start the flannel service. '''
-    status_set('maintenance', 'Starting flannel service.')
+    status.maintenance('Starting flannel service.')
     if service_running('flannel'):
         service_restart('flannel')
     else:
@@ -263,15 +265,15 @@ def update_nrpe_config(unused=None):
 def ready():
     ''' Indicate that flannel is active. '''
     try:
-        status_set('active', 'Flannel subnet ' + get_flannel_subnet())
+        status.active('Flannel subnet ' + get_flannel_subnet())
     except FlannelSubnetNotFound:
-        status_set('waiting', 'Waiting for Flannel')
+        status.waiting('Waiting for Flannel')
 
 
 @when_not('etcd.connected')
 def halt_execution():
     ''' send a clear message to the user that we are waiting on etcd '''
-    status_set('blocked', 'Waiting for etcd relation.')
+    status.blocked('Waiting for etcd relation.')
 
 
 @hook('upgrade-charm')
@@ -293,7 +295,7 @@ def reset_states_and_redeploy():
 
 @hook('pre-series-upgrade')
 def pre_series_upgrade():
-    status_set('blocked', 'Series upgrade in progress')
+    status.blocked('Series upgrade in progress')
 
 
 @hook('stop')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,28 +1,4 @@
-import sys
-from unittest.mock import MagicMock
+import charms.unit_test
 
 
-def identity(x):
-    return x
-
-
-charmhelpers = MagicMock()
-sys.modules['charmhelpers'] = charmhelpers
-sys.modules['charmhelpers.core'] = charmhelpers.core
-sys.modules['charmhelpers.core.hookenv'] = charmhelpers.core.hookenv
-sys.modules['charmhelpers.core.host'] = charmhelpers.core.host
-sys.modules['charmhelpers.contrib'] = charmhelpers.contrib
-sys.modules['charmhelpers.contrib.charmsupport'] = \
-    charmhelpers.contrib.charmsupport
-
-reactive = MagicMock()
-sys.modules['charms.reactive'] = reactive
-sys.modules['charms.reactive.helpers'] = reactive.helpers
-reactive.when.return_value = identity
-reactive.when_any.return_value = identity
-reactive.when_not.return_value = identity
-reactive.hook.return_value = identity
-
-templating = MagicMock()
-sys.modules['charms.templating'] = templating
-sys.modules['charms.templating.jinja2'] = templating.jinja2
+charms.unit_test.patch_reactive()

--- a/tests/test_flannel.py
+++ b/tests/test_flannel.py
@@ -16,6 +16,6 @@ def test_set_available():
 
 
 def test_series_upgrade():
-    assert flannel.status_set.call_count == 0
+    assert flannel.status.blocked.call_count == 0
     flannel.pre_series_upgrade()
-    assert flannel.status_set.call_count == 1
+    assert flannel.status.blocked.call_count == 1

--- a/tests/test_flannel.py
+++ b/tests/test_flannel.py
@@ -13,3 +13,9 @@ def test_set_available():
         cni_conf_file='10-flannel.conflist'
     )
     set_state.assert_called_once_with('flannel.cni.available')
+
+
+def test_series_upgrade():
+    assert flannel.status_set.call_count == 0
+    flannel.pre_series_upgrade()
+    assert flannel.status_set.call_count == 1

--- a/tox.ini
+++ b/tox.ini
@@ -16,8 +16,9 @@ deps =
     pytest
     flake8
     ipdb
+    git+https://github.com/juju-solutions/charms.unit_test/#egg=charms.unit_test
 commands = pytest --tb native -s {posargs}
 
 [testenv:lint]
 envdir = {toxworkdir}/py3
-commands = flake8 {toxinidir}
+commands = flake8 {toxinidir}/lib {toxinidir}/reactive {toxinidir}/tests


### PR DESCRIPTION
We can't actually pause the service because the series upgrade hooks run on the subordinates before the principal so doing so could interfere with the pod drain process. So instead, we just set a status to let the Juju admin know that it's ok to proceed.

Part of https://bugs.launchpad.net/charm-flannel/+bug/1869944