### PR TITLE
Pin dnspython dependency

### DIFF
--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,2 +1,3 @@
 charms.templating.jinja2>=1.0.0,<2.0.0
 python-etcd>=0.4.0,<1.0.0
+dnspython<2.0.0


### PR DESCRIPTION
The 2.0.0 release of dnspython requires Python 3.6+ so doesn't work on Xenial.

From Jenkins:

```
2020-07-31 00:59:24 DEBUG install dnspython requires Python '>=3.6' but the running Python is 3.5.2
2020-07-31 00:59:24 DEBUG install Traceback (most recent call last):
2020-07-31 00:59:24 DEBUG install   File "/var/lib/juju/agents/unit-flannel-0/charm/hooks/install", line 8, in <module>
2020-07-31 00:59:24 DEBUG install     basic.bootstrap_charm_deps()
2020-07-31 00:59:24 DEBUG install   File "lib/charms/layer/basic.py", line 207, in bootstrap_charm_deps
2020-07-31 00:59:24 DEBUG install     env=_get_subprocess_env())
2020-07-31 00:59:24 DEBUG install   File "/usr/lib/python3.5/subprocess.py", line 581, in check_call
2020-07-31 00:59:24 DEBUG install     raise CalledProcessError(retcode, cmd)
2020-07-31 00:59:24 DEBUG install subprocess.CalledProcessError: Command '['/var/lib/juju/agents/unit-flannel-0/.venv/bin/pip', 'install', '-U', '--force-reinstall', '--no-index', '--no-cache-dir', '-f', 'wheelhouse', 'Tempita', 'netaddr', 'charms.templating.jinja2', 'pyaml', 'six', 'PyYAML', 'MarkupSafe', 'wheel', 'Jinja2', 'pbr', 'dnspython', 'urllib3', 'python-etcd', 'charmhelpers', 'charms.reactive']' returned non-zero exit status 1
2020-07-31 00:59:24 ERROR juju.worker.uniter.operation runhook.go:132 hook "install" failed: exit status 1
```