### PR TITLE
Add net-tools to layer.yaml packages option

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -10,3 +10,5 @@ repo: https://github.com/juju-solutions/charm-flannel.git
 options:
   basic:
     use_venv: true
+    packages:
+      - net-tools


### PR DESCRIPTION
Apparently net-tools (and thus `route`) isn't installed by default on the Focal cloud image, and this seems like the quickest fix.

Fixes [lp:1903061](https://bugs.launchpad.net/charm-flannel/+bug/1903061)