### PR TITLE
allow the vxlan id to be configured

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -10,3 +10,13 @@ options:
     default: 10.1.0.0/16
     description: |
       Network CIDR to assign to Flannel
+  port:
+    type: int
+    default: 0
+    description: |
+      Network port to use for Flannel
+  vni:
+    type: int
+    default: 0
+    description: |
+      VXLAN network id to assign to Flannel

--- a/reactive/flannel.py
+++ b/reactive/flannel.py
@@ -207,7 +207,7 @@ def configure_network(etcd):
         return False
 
 
-@when('config.changed.cidr')
+@when('config.changed.cidr', 'config.changed.port', 'config.changed.vni')
 def reconfigure_network():
     ''' Trigger the network configuration method. '''
     remove_state('flannel.network.configured')

--- a/reactive/flannel.py
+++ b/reactive/flannel.py
@@ -207,7 +207,7 @@ def configure_network(etcd):
         return False
 
 
-@when('config.changed.cidr', 'config.changed.port', 'config.changed.vni')
+@when_any('config.changed.cidr', 'config.changed.port', 'config.changed.vni')
 def reconfigure_network():
     ''' Trigger the network configuration method. '''
     remove_state('flannel.network.configured')

--- a/reactive/flannel.py
+++ b/reactive/flannel.py
@@ -175,12 +175,22 @@ def configure_network(etcd):
     Returns True if the operation completed successfully.
 
     '''
-    data = json.dumps({
+    flannel_config = {
         'Network': config('cidr'),
         'Backend': {
             'Type': 'vxlan'
         }
-    })
+    }
+
+    vni = config('vni')
+    if vni:
+        flannel_config['Backend']['VNI'] = vni
+
+    port = config('port')
+    if port:
+        flannel_config['Backend']['Port'] = port
+
+    data = json.dumps(flannel_config)
     cmd = "etcdctl "
     cmd += "--endpoint '{0}' ".format(etcd.get_connection_string())
     cmd += "--cert-file {0} ".format(ETCD_CERT_PATH)


### PR DESCRIPTION
In order for flannel to interop with the Windows version the vxlan id and port need to be configured to 4096 and 4789 respectively[0]. This is done by adding 2 new configuration parameters and adding them into the configuration stored in etcd if the config options are present.

[0] https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes/#configuring-flannel