### PR TITLE
Fix failure to build etcdctl

### DIFF
--- a/build-flannel-resources.sh
+++ b/build-flannel-resources.sh
@@ -35,7 +35,7 @@ mkdir "$temp_dir"
       -e GOOS=linux \
       -e GOARCH="$arch" \
       -v $temp_dir/etcd:/etcd \
-      golang \
+      golang:1.15 \
       /bin/bash -c "cd /etcd && ./build && chown -R ${USER_ID}:${GROUP_ID} /etcd"
 
     rm -rf contents


### PR DESCRIPTION
Golang 1.16.0 was released 3 days ago, and the Flannel/Canal charms' etcdctl builds have been failing since:

```
13:16:32 [canal] Building etcd v2.3.7 for amd64
13:16:32 [canal] + docker run --rm -e GOOS=linux -e GOARCH=amd64 -v /var/lib/jenkins/slaves/jenkins-slave-7/workspace/build-charms/.cache/charmbuild/jenkins-build-charms-999/charms/canal/tmp/temp/flannel/build-flannel-resources.tmp/etcd:/etcd golang /bin/bash -c 'cd /etcd && ./build && chown -R 999:999 /etcd'
...
13:16:50 [canal] no required module provides package github.com/coreos/etcd: working directory is not part of a module
```

This PR fixes it by pinning to Golang 1.15.x.