### PR TITLE
Fix hook error due to missing kubernetes-common layer

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -6,6 +6,7 @@ includes:
    - 'layer:debug'
    - 'layer:nagios'
    - 'layer:status'
+   - 'layer:kubernetes-common'
 repo: https://github.com/juju-solutions/charm-flannel.git
 options:
   basic:


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/bugs/1938943 for Flannel.