### PR TITLE
Update `test_change_cidr_network`, Run integration tests on Vsphere

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,10 +31,12 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
+
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
+
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
@@ -42,8 +44,21 @@ jobs:
           credentials-yaml: ${{ secrets.CREDENTIALS_YAML }}
           clouds-yaml: ${{ secrets.CLOUDS_YAML }}
           bootstrap-options: "--model-default datastore=vsanDatastore --model-default primary-network=VLAN_2764"
-      - name: Install docker
-        # using channel candidate due https://github.com/docker-snap/docker-snap/issues/45
-        run: sudo snap install docker --candidate
+
       - name: Run integration test
         run: tox -e integration
+
+      - name: Setup Debug Artifact Collection
+        if: failure()
+        run: mkdir tmp
+
+      - name: Collect Juju Logs
+        if: failure()
+        run: juju debug-log --replay --no-tail | tee tmp/juju-status.txt
+
+      - name: Upload debug artifacts
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-run-artifacts
+          path: tmp

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,10 +15,14 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
-      - name: Install Tox
-        run: pip install tox
+      - name: Install Dependencies
+        run: |
+          pip install tox
+          sudo snap install charm --classic
       - name: Run Tox
         run: tox # Run tox using the version of Python in `PATH`
+      - name: Validate Wheelhouse
+        run: tox -vve validate-wheelhouse
 
   integration-tests:
     name: Integration test with Vsphere

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,7 +41,5 @@ jobs:
       - name: Install docker
         # using channel candidate due https://github.com/docker-snap/docker-snap/issues/45
         run: sudo snap install docker --candidate
-      - name: Build flannel resources
-        run: ARCH=amd64 sudo ./build-flannel-resources.sh
       - name: Run integration test
         run: tox -e integration

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,8 +21,9 @@ jobs:
         run: tox # Run tox using the version of Python in `PATH`
 
   integration-tests:
-    name: Integration test with LXD
-    runs-on: ubuntu-latest
+    name: Integration test with Vsphere
+    runs-on: self-hosted
+    timeout-minutes: 60
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -33,7 +34,10 @@ jobs:
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
-          provider: lxd
+          provider: vsphere
+          credentials-yaml: ${{ secrets.CREDENTIALS_YAML }}
+          clouds-yaml: ${{ secrets.CLOUDS_YAML }}
+          bootstrap-options: "--model-default datastore=vsanDatastore --model-default primary-network=VLAN_2764"
       - name: Install docker
         # using channel candidate due https://github.com/docker-snap/docker-snap/issues/45
         run: sudo snap install docker --candidate

--- a/tests/data/bundle.yaml
+++ b/tests/data/bundle.yaml
@@ -28,7 +28,9 @@ applications:
   flannel:
     charm: {{ master_charm }}
     resources:
-      {{ flannel_resource }}
+      flannel-amd64: {{flannel_amd64|default("0")}}
+      flannel-arm64: {{flannel_arm64|default("0")}}
+      flannel-s390x: {{flannel_s390x|default("0")}}
   kubernetes-master:
     charm: ch:containers-kubernetes-master
     channel: edge

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,29 +1,51 @@
+import asyncio
+import logging
+from urllib.request import urlretrieve
 from pathlib import Path
-from typing import Tuple
+import shlex
 
 import pytest
 
+log = logging.getLogger(__name__)
 
-def pytest_addoption(parser) -> None:
-    parser.addoption(
-        "--flannel-version", nargs="?", type=str, default="amd64",
-        choices=["amd64", "arm64", "s390x"],
-        help="The version of flannel resource. [amd64/arm64/s390x]"
+
+CNI_ARCH_URL = "https://api.jujucharms.com/charmstore/v5/~containers/flannel-{charm}/resource/flannel-{arch}"  # noqa
+CHUNK_SIZE = 16000
+
+
+async def _retrieve_url(charm, arch, target_file):
+    url = CNI_ARCH_URL.format(
+        charm=charm,
+        arch=arch,
     )
-    parser.addoption(
-        "--flannel-resource", nargs="?", type=Path,
-        default=Path("flannel-amd64.tar.gz"),
-        help="The path to the flannel resource. It can be compiled with "
-             "`./build-flannel-resources.sh`, see README.md for more information."
-    )
+    urlretrieve(url, target_file)
 
 
 @pytest.fixture()
-def flannel_resource(pytestconfig) -> Tuple[str, str]:
-    version = pytestconfig.getoption("--flannel-version")
-    path = pytestconfig.getoption("--flannel-resource")
-    if not path.exists():
-        raise FileNotFoundError("Missing resource, please provide via"
-                                "--flannel-resource option or at {}".format(path))
+async def setup_resources(ops_test, tmpdir):
+    """Provides the flannel resources needed to deploy the charm."""
+    cwd = Path.cwd()
+    current_resources = list(cwd.glob("*.tar.gz"))
+    if not current_resources:
+        # If they are not locally available, try to build them
+        log.info("Build Resources...")
+        build_script = cwd / "build-flannel-resources.sh"
+        rc, stdout, stderr = await ops_test.run(
+            *shlex.split("sudo " + build_script), cwd=tmpdir, check=False
+        )
+        if rc != 0:
+            err = (stderr or stdout).strip()
+            log.warning("build-flannel-resources failed: {}".format(err))
+        current_resources = list(Path(tmpdir).glob("*.tar.gz"))
+    if not current_resources:
+        # if we couldn't build them, just download a fixed version
+        log.info("Downloading Resources...")
+        await asyncio.gather(
+            *(
+                _retrieve_url(619, arch, tmpdir / "flannel-{}.tar.gz".format(arch))
+                for arch in ("amd64", "arm64", "s390x")
+            )
+        )
+        current_resources = list(Path(tmpdir).glob("*.tar.gz"))
 
-    return f"flannel-{version}",  path  # noqa: E999
+    yield current_resources

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -31,7 +31,7 @@ async def setup_resources(ops_test, tmpdir):
         log.info("Build Resources...")
         build_script = cwd / "build-flannel-resources.sh"
         rc, stdout, stderr = await ops_test.run(
-            *shlex.split("sudo " + build_script), cwd=tmpdir, check=False
+            *shlex.split("sudo {}".format(build_script)), cwd=tmpdir, check=False
         )
         if rc != 0:
             err = (stderr or stdout).strip()

--- a/tests/integration/test_flannel_integration.py
+++ b/tests/integration/test_flannel_integration.py
@@ -42,11 +42,13 @@ async def _create_test_pod(model):
             ]
         }
     }
+    log.info("Creating Test Pod")
     resp = api.create_namespaced_pod(body=pod_manifest, namespace="default")
     # wait for pod not to be in pending
     i = 0
     while resp.status.phase == "Pending" and i < 30:
         i += 1
+        log.info(f"pod pending {(i-1)*10} seconds...")
         sleep(10)
         resp = api.read_namespaced_pod("test", namespace="default")
 
@@ -62,7 +64,9 @@ async def validate_flannel_cidr_network(ops_test):
 
     for unit in flannel.units:
         assert unit.workload_status == "active"
-        assert _get_flannel_subnet_ip(unit) in cidr_network
+        subnet = _get_flannel_subnet_ip(unit)
+        log.info(f"{unit.name} reports subnet {subnet}")
+        assert subnet in cidr_network
 
     # create test pod
     resp = await _create_test_pod(ops_test.model)
@@ -103,21 +107,33 @@ async def test_change_cidr_network(ops_test):
     """Test configuration change."""
     flannel = ops_test.model.applications["flannel"]
     await flannel.set_config({"cidr": "10.2.0.0/16"})
-    rc, stdout, stderr = await ops_test.run(
-        "juju", "run", "-m", ops_test.model_full_name, "--application", "flannel",
-        "--", "hooks/config-changed"
+    rc, stdout, stderr = await ops_test.juju(
+        "run", "-m", ops_test.model_full_name,
+        "--application", "flannel", "hooks/update-status"
     )
     assert rc == 0, f"Failed to run hook with resource: {stderr or stdout}"
 
-    # note (rgildein): There is need to restart kubernetes-worker machine.
+    # note (rgildein): There is need to restart kubernetes-worker machines.
     #                  https://bugs.launchpad.net/charm-flannel/+bug/1932551
-    k8s_worker = ops_test.model.applications["kubernetes-worker"].units[0]
-    rc, stdout, stderr = await ops_test.juju(
-        "ssh", "-m", ops_test.model_full_name, f"{k8s_worker.name}",
-        "--", "sudo su root -c '(sleep 5; reboot) &'"
-    )
-    assert rc == 0, ("Failed to restart kubernetes-worker with "
-                     f"resource: {stderr or stdout}")
+    for k8s_worker in ops_test.model.applications["kubernetes-worker"].units:
+        rc, stdout, stderr = await ops_test.juju(
+            "run", "-m", ops_test.model_full_name, "--unit", k8s_worker.name,
+            "sudo su root -c '(sleep 5; reboot) &'"
+        )
+        assert rc == 0, (f"Failed to restart {k8s_worker.name} with "
+                         f"resource: {stderr or stdout}")
+        log.info(f"Rebooting {k8s_worker.name}...{stderr or stdout}")
 
-    await ops_test.model.wait_for_idle(status="active", timeout=10 * 60, idle_period=60)
+    await ops_test.model.wait_for_idle(
+        status="active", timeout=10 * 60, idle_period=60, raise_on_error=False
+    )
+
+    for k8s_worker in ops_test.model.applications["kubernetes-worker"].units:
+        rc, stdout, stderr = await ops_test.juju(
+            "run", "-m", ops_test.model_full_name, "--unit", k8s_worker.name, "uptime"
+        )
+        assert rc == 0, (f"Failed to restart {k8s_worker.name} with "
+                         f"resource: {stderr or stdout}")
+        log.info(f"Reboot complete {k8s_worker.name}: {stderr or stdout}")
+    log.info("Stability reached after reboot")
     await validate_flannel_cidr_network(ops_test)

--- a/tests/validate-wheelhouse.sh
+++ b/tests/validate-wheelhouse.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+build_dir="$(mktemp -d)"
+function cleanup { rm -rf "$build_dir"; }
+trap cleanup EXIT
+
+charm build . --build-dir "$build_dir" --debug
+pip install -f "$build_dir/flannel/wheelhouse" --no-index --no-cache-dir "$build_dir"/flannel/wheelhouse/*

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,16 @@ deps =
     git+https://github.com/juju-solutions/charms.unit_test/#egg=charms.unit_test
 commands = pytest --tb native -s {posargs} {toxinidir}/tests/unit
 
+[testenv:validate-wheelhouse]
+deps =
+# Temporarily pin setuptools to avoid the breaking change from 58 until
+# all dependencies we use have a chance to update.
+# See: https://setuptools.readthedocs.io/en/latest/history.html#v58-0-0
+# and: https://github.com/pypa/setuptools/issues/2784#issuecomment-917663223
+    setuptools<58
+allowlist_externals = {toxinidir}/tests/validate-wheelhouse.sh
+commands = {toxinidir}/tests/validate-wheelhouse.sh
+
 [testenv:lint]
 deps = flake8
 commands = flake8 {toxinidir}/lib {toxinidir}/reactive {toxinidir}/tests


### PR DESCRIPTION
Adds in 
* additional debugging logging during integration tests
* more safely handles unit reboots 
* wait for idle after the reboot so that `ops_test` doesn't fail on the lost machine unit. 
* automatically build flannel resources during integration tests
* download flannel resources if building isn't possible