### PR TITLE
Removing linting on py3.5, add py3.10

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -64,7 +64,8 @@ jobs:
           provider: vsphere
           credentials-yaml: ${{ secrets.CREDENTIALS_YAML }}
           clouds-yaml: ${{ secrets.CLOUDS_YAML }}
-          bootstrap-options: "--model-default datastore=vsanDatastore --model-default primary-network=VLAN_2764"
+          bootstrap-options: "${{ secrets.FOCAL_BOOTSTRAP_OPTIONS }} --model-default datastore=vsanDatastore --model-default primary-network=VLAN_2764"
+          bootstrap-constraints: "arch=amd64 cores=2 mem=4G"
 
       - name: Run integration test
         run: tox -e integration

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.6, 3.7, 3.8, 3.9]
+        python: ['3.6', '3.7', '3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python: [3.6, 3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python
@@ -41,9 +41,7 @@ jobs:
         env:
           python_dot_version: ${{ matrix.python }}
         run: |
-          lint="lint"
-          if [[ "${python_dot_version}" == "3.5" ]] ; then lint="py35-lint"; fi
-          tox -e $lint,unit
+          tox -e lint,unit
       - name: Validate Wheelhouse
         run: tox -vve validate-wheelhouse
 


### PR DESCRIPTION
DEPRECATION: Python 3.5 reached the end of its life on September 13th 2020. Please upgrade your Python as Python 3.5 is no longer maintained. pip 21.0 will drop support for Python 3.5 in January 2021. pip 21.0 will remove support for this functionality.