### PR TITLE
Bump Flannel to v0.20.2.

### DIFF
--- a/build-flannel-resources.sh
+++ b/build-flannel-resources.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eux
 
-FLANNEL_VERSION=${FLANNEL_VERSION:-"v0.11.0"}
+FLANNEL_VERSION=${FLANNEL_VERSION:-"v0.20.2"}
 ETCD_VERSION=${ETCD_VERSION:-"v2.3.7"}
 
 ARCH=${ARCH:-"amd64 arm64 s390x"}


### PR DESCRIPTION
The main motivation for the version bump is to provide the fix for https://github.com/flannel-io/flannel/issues/1474, which I believe is affecting pods on my Kubernetes cluster.

I'm not sure how to test such a potentially broad change myself, so am hoping to be able to run the CI pipeline here against it to see what happens.

Related to https://bugs.launchpad.net/charm-flannel/+bug/2004150.