### PR TITLE
switch from flannel v0.11.0 to v0.20.2

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,18 +23,38 @@ jobs:
     name: Lint Unit
     uses: charmed-kubernetes/workflows/.github/workflows/lint-unit.yaml@main
 
+  resources-build:
+    name: Build Resources with docker
+    runs-on: ubuntu-22.04
+    needs:
+      - lint-unit
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Install Docker
+        run:  sudo snap install docker
+      - name: Build Resources
+        run:  sudo ./build-flannel-resources.sh
+      - name: Upload resource artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: flannel-resources
+          path: ./flannel*.tar.gz
+
   integration-tests:
     name: Integration test with Vsphere
     runs-on: self-hosted
     timeout-minutes: 60
+    needs:
+      - resources-build
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.8
 
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
@@ -44,6 +64,11 @@ jobs:
           clouds-yaml: ${{ secrets.CLOUDS_YAML }}
           bootstrap-options: "${{ secrets.FOCAL_BOOTSTRAP_OPTIONS }} --model-default datastore=vsanDatastore --model-default primary-network=VLAN_2764"
           bootstrap-constraints: "arch=amd64 cores=2 mem=4G"
+
+      - name: Download resource artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: flannel-resources
 
       - name: Run integration test
         run: tox -e integration

--- a/build-flannel-resources.sh
+++ b/build-flannel-resources.sh
@@ -2,7 +2,7 @@
 set -eux
 
 FLANNEL_VERSION=${FLANNEL_VERSION:-"v0.20.2"}
-ETCD_VERSION=${ETCD_VERSION:-"v2.3.7"}
+ETCD_VERSION=${ETCD_VERSION:-"v3.4.22"}
 
 ARCH=${ARCH:-"amd64 arm64 s390x"}
 
@@ -42,7 +42,7 @@ mkdir "$temp_dir"
       -e GOOS=linux \
       -e GOARCH="$arch" \
       -v $temp_dir/etcd:/etcd \
-      golang:1.15 \
+      golang:1.19 \
       /bin/bash -c "cd /etcd && ./build && chown -R ${USER_ID}:${GROUP_ID} /etcd"
 
     rm -rf contents

--- a/build-flannel-resources.sh
+++ b/build-flannel-resources.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eux
 
-FLANNEL_VERSION=${FLANNEL_VERSION:-"v0.11.0"}
+FLANNEL_VERSION=${FLANNEL_VERSION:-"v0.20.2"}
 ETCD_VERSION=${ETCD_VERSION:-"v2.3.7"}
 
 ARCH=${ARCH:-"amd64 arm64 s390x"}

--- a/reactive/flannel.py
+++ b/reactive/flannel.py
@@ -190,14 +190,16 @@ def configure_network(etcd):
         flannel_config["Backend"]["Port"] = port
 
     data = json.dumps(flannel_config)
+
     cmd = "etcdctl "
-    cmd += "--endpoint '{0}' ".format(etcd.get_connection_string())
-    cmd += "--cert-file {0} ".format(ETCD_CERT_PATH)
-    cmd += "--key-file {0} ".format(ETCD_KEY_PATH)
-    cmd += "--ca-file {0} ".format(ETCD_CA_PATH)
-    cmd += "set /coreos.com/network/config '{0}'".format(data)
+    cmd += "--endpoints '{0}' ".format(etcd.get_connection_string())
+    cmd += "--cert {0} ".format(ETCD_CERT_PATH)
+    cmd += "--key {0} ".format(ETCD_KEY_PATH)
+    cmd += "--cacert {0} ".format(ETCD_CA_PATH)
+    cmd += "put /coreos.com/network/config '{0}'".format(data)
+    env = dict(os.environ, ETCDCTL_API="3")
     try:
-        check_call(split(cmd))
+        check_call(split(cmd), env=env)
         return True
 
     except CalledProcessError:

--- a/tests/integration/test_flannel_integration.py
+++ b/tests/integration/test_flannel_integration.py
@@ -40,7 +40,11 @@ async def _create_test_pod(model):
         "metadata": {"name": "test"},
         "spec": {
             "containers": [
-                {"image": "busybox", "name": "test", "args": ["echo", '"test"']}
+                {
+                    "image": "rocks.canonical.com/cdk/busybox:1.32",
+                    "name": "test",
+                    "args": ["echo", '"test"'],
+                }
             ]
         },
     }

--- a/tests/integration/test_flannel_integration.py
+++ b/tests/integration/test_flannel_integration.py
@@ -90,7 +90,7 @@ async def test_build_and_deploy(ops_test, series: str, snap_channel: str):
         log.info("Build Charm...")
         charm = await ops_test.build_charm(".")
 
-    resources = next(Path.cwd().glob("flannel*.tar.gz"), None)
+    resources = list(Path.cwd().glob("flannel*.tar.gz"))
     if not resources:
         log.info("Build Resources...")
         build_script = Path.cwd() / "build-flannel-resources.sh"

--- a/tests/integration/test_flannel_integration.py
+++ b/tests/integration/test_flannel_integration.py
@@ -90,8 +90,11 @@ async def test_build_and_deploy(ops_test, series: str, snap_channel: str):
         log.info("Build Charm...")
         charm = await ops_test.build_charm(".")
 
-    build_script = Path.cwd() / "build-flannel-resources.sh"
-    resources = await ops_test.build_resources(build_script, with_sudo=False)
+    resources = next(Path.cwd().glob("flannel*.tar.gz"), None)
+    if not resources:
+        log.info("Build Resources...")
+        build_script = Path.cwd() / "build-flannel-resources.sh"
+        resources = await ops_test.build_resources(build_script, with_sudo=False)
     expected_resources = {"flannel-amd64", "flannel-arm64", "flannel-s390x"}
 
     if resources and all(remove_ext(rsc) in expected_resources for rsc in resources):


### PR DESCRIPTION
Re-raising PR from an org branch

quoting @alexpearce in https://github.com/charmed-kubernetes/charm-flannel/pull/85
> The main motivation for the version bump is to provide the fix for https://github.com/flannel-io/flannel/issues/1474, which I believe is affecting pods on my Kubernetes cluster.
> I'm not sure how to test such a potentially broad change myself, so am hoping to be able to run the CI pipeline here against it to see what happens.
> Related to https://bugs.launchpad.net/charm-flannel/+bug/2004150.