### PR TITLE
disable vcs stamping during go build

### DIFF
--- a/build-flannel-resources.sh
+++ b/build-flannel-resources.sh
@@ -41,6 +41,7 @@ mkdir "$temp_dir"
       --rm \
       -e GOOS=linux \
       -e GOARCH="$arch" \
+      -e GOFLAGS=-buildvcs=false \
       -v $temp_dir/etcd:/etcd \
       golang:1.19 \
       /bin/bash -c "cd /etcd && ./build && chown -R ${USER_ID}:${GROUP_ID} /etcd"


### PR DESCRIPTION
`build-charms` is failing to build the flannel etcd resource because go 1.18+ attempts to embed vcs info into the build. Flannel builds etcd with a `golang` image that does not include git, so the build fails, e.g.:

https://jenkins.canonical.com/k8s/job/build-charms/763/consoleFull

This PR disables buildvcs for the etcd portion of the flannel resource build.

Fixes: https://bugs.launchpad.net/charm-flannel/+bug/2006742