### PR TITLE
omit version control information in the built etcdctl binary

### DIFF
--- a/build-flannel-resources.sh
+++ b/build-flannel-resources.sh
@@ -41,6 +41,7 @@ mkdir "$temp_dir"
       --rm \
       -e GOOS=linux \
       -e GOARCH="$arch" \
+      -e GOFLAGS="-buildvcs=false" \
       -v $temp_dir/etcd:/etcd \
       golang:1.19 \
       /bin/bash -c "cd /etcd && ./build && chown -R ${USER_ID}:${GROUP_ID} /etcd"


### PR DESCRIPTION
https://tip.golang.org/doc/go1.18

> The go command now embeds version control information in binaries. It includes the currently checked-out revision, commit time, and a flag indicating whether edited or untracked files are present. Version control information is embedded if the go command is invoked in a directory within a Git, Mercurial, Fossil, or Bazaar repository, and the main package and its containing main module are in the same repository. This information may be omitted using the flag -buildvcs=false.

