### PR TITLE
Add flannel cni-plugin 1.2.0, update to flanneld 0.22.1

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -54,12 +54,13 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: '3.10'
 
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: vsphere
+          juju-channel: 3.1/stable
           credentials-yaml: ${{ secrets.CREDENTIALS_YAML }}
           clouds-yaml: ${{ secrets.CLOUDS_YAML }}
           bootstrap-options: "${{ secrets.FOCAL_BOOTSTRAP_OPTIONS }} --model-default datastore=vsanDatastore --model-default primary-network=VLAN_2764"
@@ -71,7 +72,7 @@ jobs:
           name: flannel-resources
 
       - name: Run integration test
-        run: tox -e integration
+        run: tox -e integration -- --basetemp=/home/ubuntu/pytest
 
       - name: Setup Debug Artifact Collection
         if: failure()

--- a/reactive/flannel.py
+++ b/reactive/flannel.py
@@ -1,5 +1,6 @@
 import os
 import json
+import shutil
 from shlex import split
 from subprocess import check_output, check_call, CalledProcessError, STDOUT
 
@@ -63,6 +64,8 @@ def install_flannel_binaries():
         app_path = os.path.join(app["path"], app["name"])
         install = ["install", "-v", "-D", unpacked, app_path]
         check_call(install)
+    os.makedirs("/opt/cni/bin", exist_ok=True)
+    shutil.copy(unpack_path + "/cni-plugin/flannel", "/opt/cni/bin")
     set_state("flannel.binaries.installed")
 
 

--- a/tests/integration/test_flannel_integration.py
+++ b/tests/integration/test_flannel_integration.py
@@ -2,6 +2,7 @@ import json
 import logging
 import re
 import shlex
+import shutil
 from ipaddress import ip_address, ip_network
 from pathlib import Path
 from time import sleep
@@ -95,7 +96,14 @@ async def test_build_and_deploy(ops_test, series: str, snap_channel: str):
         charm = await ops_test.build_charm(".")
 
     resources = list(Path.cwd().glob("flannel*.tar.gz"))
-    if not resources:
+    if resources:
+        log.info("Using pre-built resources...")
+        resource_dir = ops_test.tmp_path / "resources"
+        resource_dir.mkdir(exist_ok=True)
+        for resource in resources:
+            shutil.copy(resource, resource_dir)
+        resources = list(resource_dir.glob("*"))
+    else:
         log.info("Build Resources...")
         build_script = Path.cwd() / "build-flannel-resources.sh"
         resources = await ops_test.build_resources(build_script, with_sudo=False)

--- a/tests/integration/test_flannel_integration.py
+++ b/tests/integration/test_flannel_integration.py
@@ -140,7 +140,7 @@ async def test_change_cidr_network(ops_test):
     flannel = ops_test.model.applications["flannel"]
     await flannel.set_config({"cidr": "10.2.0.0/16"})
     rc, stdout, stderr = await ops_test.juju(
-        "run",
+        "exec",
         "-m",
         ops_test.model_full_name,
         "--application",
@@ -175,7 +175,7 @@ async def test_change_cidr_network(ops_test):
 
     for k8s_worker in ops_test.model.applications["kubernetes-worker"].units:
         rc, stdout, stderr = await ops_test.juju(
-            "run", "-m", ops_test.model_full_name, "--unit", k8s_worker.name, "uptime"
+            "exec", "-m", ops_test.model_full_name, "--unit", k8s_worker.name, "uptime"
         )
         assert rc == 0, "Failed to fetch uptime @{name} with error: {err}".format(
             name=k8s_worker.name, err=stderr or stdout


### PR DESCRIPTION
https://bugs.launchpad.net/bugs/2007425

The Flannel CNI plugin is no longer included with the core CNI plugins delivered by kubernetes-control-plane and kubernetes-worker. It's now a standalone project that we need to build and install as part of the Flannel charm.

Since we're making changes here anyway, also bump to Flannel 0.22.1.