### PR TITLE
unblocking launchpad builds of charm

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -21,7 +21,9 @@ parts:
     - https://raw.githubusercontent.com/charmed-kubernetes/layer-index/main/
     - --debug
     - --force
-    build-snaps: 
+    build-packages:
+    - python3-dev
+    build-snaps:
     - charm/3.x/stable
     build-environment:
     - CHARM_INTERFACES_DIR: $CRAFT_PROJECT_DIR/interfaces/


### PR DESCRIPTION
### Overview
After merging #92, launchpad builds of this charm are failing with missing `Python.h` from `python3-dev` package. 
